### PR TITLE
Fix: Add generate-sprint command to install script and tests

### DIFF
--- a/install.js
+++ b/install.js
@@ -92,7 +92,7 @@ directories.forEach(dir => {
 
 // Step 3: Symlink Claude commands
 log('\n🔗 Step 3: Symlinking Claude commands...', 'bright');
-const commands = ['orchestrator.md', 'workstream-agent.md'];
+const commands = ['orchestrator.md', 'workstream-agent.md', 'generate-sprint.md'];
 const commandsSourceDir = path.join(frameworkDir, '.claude/commands');
 const commandsTargetDir = path.join(projectRoot, '.claude/commands');
 
@@ -329,7 +329,8 @@ This directory contains configuration and data for the Sprint Orchestrator frame
 .claude/
 ├── commands/              # Claude Code slash commands (symlinked from sprint-orchestrator)
 │   ├── orchestrator.md        → ../../sprint-orchestrator/.claude/commands/orchestrator.md
-│   └── workstream-agent.md    → ../../sprint-orchestrator/.claude/commands/workstream-agent.md
+│   ├── workstream-agent.md    → ../../sprint-orchestrator/.claude/commands/workstream-agent.md
+│   └── generate-sprint.md     → ../../sprint-orchestrator/.claude/commands/generate-sprint.md
 ├── workflow/              # Workflow documentation (symlinked from sprint-orchestrator)
 │   ├── sprint-workstreams.md      → ../../sprint-orchestrator/.claude/workflow/sprint-workstreams.md
 │   └── sprint-status-management.md → ../../sprint-orchestrator/.claude/workflow/sprint-status-management.md
@@ -373,6 +374,7 @@ This directory contains configuration and data for the Sprint Orchestrator frame
 In Claude Code, use:
 - \`/orchestrator\` - Initialize as sprint orchestrator
 - \`/workstream-agent <name>\` - Initialize as workstream agent
+- \`/generate-sprint\` - Generate sprint backlog files from project documentation
 
 ## Documentation
 
@@ -450,7 +452,12 @@ Project description and Claude Code integration guide.
 ### Starting Workstream Agent Mode
 **Just say**: \`/workstream-agent <workstream-name>\`
 **What it does**: Initializes you as a Workstream Agent to work on specific tasks
-**See**: [Sprint Workstreams Workflow](.claude/workflow/sprint-workstreams.md) | [Workstream Agent Command](.claude/commands/workstream-agent.md)${frameworkReference}
+**See**: [Sprint Workstreams Workflow](.claude/workflow/sprint-workstreams.md) | [Workstream Agent Command](.claude/commands/workstream-agent.md)
+
+### Generating Sprint Backlogs
+**Just say**: \`/generate-sprint [--max-story-points=40] [--docs="docs/,README.md"]\`
+**What it does**: Generate sprint backlog files from project documentation
+**See**: [Generate Sprint Command](.claude/commands/generate-sprint.md)${frameworkReference}
 `;
   fs.writeFileSync(claudeMdPath, templateContent);
   success('Created CLAUDE.md template with Sprint Orchestrator integration');

--- a/tests/unit/test-install.js
+++ b/tests/unit/test-install.js
@@ -83,16 +83,20 @@ test('install.js creates symlinks for commands', () => {
   // Check that symlinks exist
   const orchestratorLink = '.claude/commands/orchestrator.md';
   const workstreamAgentLink = '.claude/commands/workstream-agent.md';
+  const generateSprintLink = '.claude/commands/generate-sprint.md';
   
   assert.ok(setup.fileExists(orchestratorLink), 'orchestrator.md symlink should exist');
   assert.ok(setup.fileExists(workstreamAgentLink), 'workstream-agent.md symlink should exist');
+  assert.ok(setup.fileExists(generateSprintLink), 'generate-sprint.md symlink should exist');
   
   // Verify they are symlinks
   const orchestratorStat = fs.lstatSync(orchestratorLink);
   const workstreamAgentStat = fs.lstatSync(workstreamAgentLink);
+  const generateSprintStat = fs.lstatSync(generateSprintLink);
   
   assert.ok(orchestratorStat.isSymbolicLink(), 'orchestrator.md should be a symlink');
   assert.ok(workstreamAgentStat.isSymbolicLink(), 'workstream-agent.md should be a symlink');
+  assert.ok(generateSprintStat.isSymbolicLink(), 'generate-sprint.md should be a symlink');
 });
 
 test('install.js creates symlinks for workflow documentation', () => {
@@ -199,6 +203,8 @@ test('install.js creates .claude/README.md', () => {
   
   const content = setup.readFile(readmePath);
   assert.ok(content.includes('Sprint Orchestrator'), 'README should mention Sprint Orchestrator');
+  assert.ok(content.includes('generate-sprint.md'), 'README should include generate-sprint.md in structure');
+  assert.ok(content.includes('/generate-sprint'), 'README should include /generate-sprint command');
 });
 
 test('install.js creates or updates CLAUDE.md', () => {
@@ -211,6 +217,9 @@ test('install.js creates or updates CLAUDE.md', () => {
   
   const content = setup.readFile(claudeMdPath);
   assert.ok(content.includes('Sprint Orchestrator Framework'), 'CLAUDE.md should reference framework');
+  assert.ok(content.includes('/orchestrator'), 'CLAUDE.md should include /orchestrator command');
+  assert.ok(content.includes('/workstream-agent'), 'CLAUDE.md should include /workstream-agent command');
+  assert.ok(content.includes('/generate-sprint'), 'CLAUDE.md should include /generate-sprint command');
 });
 
 test('install.js handles existing symlinks correctly', () => {


### PR DESCRIPTION
- Add generate-sprint.md to commands array in install.js
- Include /generate-sprint command in CLAUDE.md template
- Update .claude/README.md to document generate-sprint.md
- Add unit tests to verify generate-sprint.md symlink creation
- Add tests to verify /generate-sprint is included in generated files